### PR TITLE
replay: Add --proxy command-line flag to control PROXY v2 behavior

### DIFF
--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -73,6 +73,10 @@ struct Opts {
     #[clap(long, default_value = "10")]
     num_sockets: usize,
 
+    /// Whether to add PROXY v2 header to re-sent DNS queries
+    #[clap(long)]
+    proxy: bool,
+
     /// Unix socket path to listen on
     #[clap(long, name = "PATH")]
     unix: String,
@@ -123,6 +127,7 @@ impl Server {
                 self.channel_receiver.clone(),
                 self.channel_mismatch_sender.clone(),
                 self.opts.dns,
+                self.opts.proxy,
             )
             .await?;
 
@@ -137,6 +142,9 @@ impl Server {
             "Sending DNS queries to server {} using {} UDP query sockets",
             &self.opts.dns, self.opts.num_sockets,
         );
+        if self.opts.proxy {
+            info!("Sending DNS queries with PROXY v2 header");
+        }
 
         // Bind to the configured Unix socket. Remove the socket file if it exists.
         let _ = std::fs::remove_file(&self.opts.unix);

--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -53,3 +53,12 @@ pub static DNS_QUERIES: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static DNSTAP_PAYLOADS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "dnstap_payloads_total",
+        "Number of dnstap payloads processed.",
+        &["result"]
+    )
+    .unwrap()
+});


### PR DESCRIPTION
This commit adds a `--proxy` command-line flag to the dnstap-replay utility and makes it optional for the DnstapHandler to prepend a PROXY v2 header to the DNS query message. This makes dnstap-replay usable with DNS servers that don't implement support for the PROXY v2 header.

The DnstapHandler code that extracts the required dnstap fields and formats them into the PROXY v2 payload has been factored out into a standalone function and the error returns from this function are now handled with a new `dnstap_payloads_total` metric.