### PR TITLE
Rename "mismatches" to "errors" in most cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Rust programming language.
 messages from one or more DNS nameservers and replays them against a
 target nameserver.  The responses from the target nameserver are
 compared against the originally logged response messages and any
-***mismatches*** are made available in dnstap format via an HTTP
-endpoint for later analysis.
+***mismatches*** or other errors are made available in dnstap format
+via an HTTP endpoint for later analysis.
 
 ### `dnstap-replay`: dnstap message requirements
 
@@ -92,11 +92,11 @@ When `dnstap-replay` sends a DNS query to the target nameserver and the
 response from the target nameserver does not exactly match the
 originally logged response message, a log message containing the
 mismatched response message is generated and buffered and can be
-retrieved from the `/mismatches` HTTP endpoint. This endpoint drains the
-mismatch buffer and provides the output in Frame Streams format
-containing dnstap payloads.
+retrieved from the `/errors` HTTP endpoint. This endpoint drains the
+error buffer and provides the output in Frame Streams format containing
+dnstap payloads.
 
-The dnstap log messages exported via the `/mismatches` endpoint are the
+The dnstap log messages exported via the `/errors` endpoint are the
 originally logged dnstap messages received by `dnstap-replay`, with the
 dnstap [`extra`
 field](https://github.com/dnstap/dnstap.pb/blob/9bafb5b59dacc48a6ff6a839e419e540f1201c42/dnstap.proto#L37-L40)
@@ -123,7 +123,7 @@ The `--unix` argument specifies the filesystem path to bind the dnstap
 Unix socket to.
 
 Additionally, there are command-line options `--channel-capacity` and
-`--channel-mismatch-capacity` which allow tuning of internal buffer
+`--channel-error-capacity` which allow tuning of internal buffer
 sizes.
 
 For example, the following command-line invocation will listen on the
@@ -140,8 +140,8 @@ be sent to the target nameserver which should be configured to listen on
 The Prometheus metrics endpoint can be accessed at
 `http://127.0.0.1:53080/metrics`.
 
-The Frame Streams mismatches endpoint can be accessed at
-`http://127.0.0.1:53080/mismatches`.
+The Frame Streams errors endpoint can be accessed at
+`http://127.0.0.1:53080/errors`.
 
 ## License
 

--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -2,19 +2,19 @@ use once_cell::sync::Lazy;
 use prometheus::{opts, register_int_counter, register_int_counter_vec};
 use prometheus::{IntCounter, IntCounterVec};
 
-pub static CHANNEL_MISMATCH_RX: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static CHANNEL_ERROR_RX: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "channel_mismatch_rx_total",
-        "Number of channel mismatch receives performed.",
+        "channel_error_rx_total",
+        "Number of error channel receives performed.",
         &["result"]
     )
     .unwrap()
 });
 
-pub static CHANNEL_MISMATCH_TX: Lazy<IntCounterVec> = Lazy::new(|| {
+pub static CHANNEL_ERROR_TX: Lazy<IntCounterVec> = Lazy::new(|| {
     register_int_counter_vec!(
-        "channel_mismatch_tx_total",
-        "Number of channel mismatch sends performed.",
+        "channel_error_tx_total",
+        "Number of error channel sends performed.",
         &["result"]
     )
     .unwrap()


### PR DESCRIPTION
This commit renames "mismatches" to "errors" in most cases (especially, the `/mismatches` HTTP endpoint which is now `/errors`, as well as some of the metrics). The term "mismatches" was being used too loosely to mean errors in general after additional types of errors were added to the HTTP endpoint. For instance, timeouts are a type of error that is not a mismatch, and it's important to log these queries through what is now the `/errors` endpoint, since a timeout could be caused for instance by a nameserver crash.

The term "mismatch" is still used to specifically mean an error that is actually a mismatch.