### PR TITLE
replay: Discard non-UDP queries

### DIFF
--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -62,3 +62,12 @@ pub static DNSTAP_PAYLOADS: Lazy<IntCounterVec> = Lazy::new(|| {
     )
     .unwrap()
 });
+
+pub static DNSTAP_HANDLER_INTERNAL_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
+    register_int_counter_vec!(
+        "dnstap_handler_internal_errors_total",
+        "Number of internal errors encountered by dnstap handler.",
+        &["result"]
+    )
+    .unwrap()
+});


### PR DESCRIPTION
This branch adds a requirement to the DnstapHandler so that only UDP queries are re-sent. Since the queries being re-sent are delivered over a UDP socket, they may elicit different response behavior if the originally logged transaction used a different transport protocol.

E.g., Knot DNS can respond with RCODE "NOTAUTH" for an unauthorized QTYPE=AXFR query received over TCP, but the same query received over UDP will elicit RCODE "NOTIMP" (since AXFR over UDP isn't specified and thus not implemented in knotd).

The full-fledged solution would be to implement the ability to replay TCP queries over TCP transport to the server under test, but for now discarding non-UDP dnstap payloads will avoid causing mismatches.

A new metric has also been added for non-UDP discards so they can be distinguished from other errors.