### PR TITLE
publish RX counter at same time as TX counter

### DIFF
--- a/src/bin/dnstap-replay/dnstap_handler.rs
+++ b/src/bin/dnstap-replay/dnstap_handler.rs
@@ -350,11 +350,15 @@ impl DnstapHandler {
     fn send_error(&self, d: dnstap::Dnstap) {
         match self.channel_error_sender.try_send(d) {
             Ok(_) => {
+                crate::metrics::CHANNEL_ERROR_RX
+                    .with_label_values(&["success"]);
                 crate::metrics::CHANNEL_ERROR_TX
                     .with_label_values(&["success"])
                     .inc();
             }
             Err(_) => {
+                crate::metrics::CHANNEL_ERROR_RX
+                    .with_label_values(&["success"]);
                 crate::metrics::CHANNEL_ERROR_TX
                     .with_label_values(&["error"])
                     .inc();


### PR DESCRIPTION
In order to avoid the case where we must deal with discontinuous metrics in
the downstream, publish a (zero) counter to the metrics system at the same
time as we publish an inc()rementing counter for the first time that we try to
save a message for later pickup.

This avoids (unnecessary) gymnastics in the alerting system when trying to
compare present (or absent) RX metrics with present TX metrics.