### PR TITLE
replay: Initialize metrics at startup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,10 +17,11 @@ futures = "0.3.16"
 heck = "0.3.3"
 hex = "0.4.3"
 hyper = { version = "0.14.12", features = ["server", "stream", "http1", "tcp"] }
+lazy_static = "1.4.0"
 libc = "0.2.107"
 log = "0.4.14"
-once_cell = "1.8.0"
 prometheus = { version = "0.12.0" }
+prometheus-static-metric = "0.5.1"
 prost = "0.8.0"
 simple-error = "0.2.3"
 stderrlog = "0.5.1"

--- a/src/bin/dnstap-replay/http_handler.rs
+++ b/src/bin/dnstap-replay/http_handler.rs
@@ -134,9 +134,7 @@ fn dnstap_receiver_to_stream(
             match channel.try_recv() {
                 Ok(d) => {
                     // Accounting.
-                    crate::metrics::CHANNEL_ERROR_RX
-                        .with_label_values(&["success"])
-                        .inc();
+                    crate::metrics::CHANNEL_ERROR_RX.success.inc();
 
                     // Get the length of the serialized protobuf.
                     let len = d.encoded_len();

--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -201,6 +201,8 @@ fn main() -> Result<()> {
         .init()
         .unwrap();
 
+    metrics::initialize_metrics();
+
     let mut server = Server::new(&opts);
 
     // Start the Tokio runtime.

--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -1,73 +1,113 @@
-use once_cell::sync::Lazy;
-use prometheus::{opts, register_int_counter, register_int_counter_vec};
-use prometheus::{IntCounter, IntCounterVec};
+use lazy_static::{initialize, lazy_static};
+use prometheus::{opts, register_int_counter, register_int_counter_vec, IntCounter};
+use prometheus_static_metric::{make_static_metric, register_static_int_counter_vec};
 
-pub static CHANNEL_ERROR_RX: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+make_static_metric! {
+    pub struct ChannelErrorRxVec: IntCounter {
+        "result" => {
+            success,
+        },
+    }
+
+    pub struct ChannelErrorTxVec: IntCounter {
+        "result" => {
+            success,
+            error,
+        },
+    }
+
+    pub struct DnsComparisonsVec: IntCounter {
+        "result" => {
+            matched,
+            mismatched,
+        },
+    }
+
+    pub struct DnsQueriesVec: IntCounter {
+        "result" => {
+            success,
+            error,
+            timeout,
+        },
+    }
+
+    pub struct DnstapPayloadsVec: IntCounter {
+        "result" => {
+            success,
+            error,
+        },
+    }
+
+    pub struct DnstapHandlerInternalErrorsVec: IntCounter {
+        "result" => {
+            discard_non_udp,
+        },
+    }
+}
+
+lazy_static! {
+    pub static ref CHANNEL_ERROR_RX: ChannelErrorRxVec = register_static_int_counter_vec!(
+        ChannelErrorRxVec,
         "dnstap_replay_channel_error_rx_total",
         "Number of error channel receives performed.",
         &["result"]
     )
-    .unwrap()
-});
-
-pub static CHANNEL_ERROR_TX: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    .unwrap();
+    pub static ref CHANNEL_ERROR_TX: ChannelErrorTxVec = register_static_int_counter_vec!(
+        ChannelErrorTxVec,
         "dnstap_replay_channel_error_tx_total",
         "Number of error channel sends performed.",
         &["result"]
     )
-    .unwrap()
-});
-
-pub static DATA_FRAMES: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(opts!(
-        "dnstap_replay_data_frames_total",
-        "Number of Frame Streams data frames processed."
-    ))
-    .unwrap()
-});
-
-pub static DATA_BYTES: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(opts!(
+    .unwrap();
+    pub static ref DATA_BYTES: IntCounter = register_int_counter!(opts!(
         "dnstap_replay_data_bytes_total",
         "Number of Frame Streams data frame bytes processed."
     ))
-    .unwrap()
-});
-
-pub static DNS_COMPARISONS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    .unwrap();
+    pub static ref DATA_FRAMES: IntCounter = register_int_counter!(opts!(
+        "dnstap_replay_data_frames_total",
+        "Number of Frame Streams data frames processed."
+    ))
+    .unwrap();
+    pub static ref DNS_COMPARISONS: DnsComparisonsVec = register_static_int_counter_vec!(
+        DnsComparisonsVec,
         "dnstap_replay_dns_comparisons_total",
         "Number of DNS comparison operations performed.",
         &["result"]
     )
-    .unwrap()
-});
-
-pub static DNS_QUERIES: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    .unwrap();
+    pub static ref DNS_QUERIES: DnsQueriesVec = register_static_int_counter_vec!(
+        DnsQueriesVec,
         "dnstap_replay_dns_queries_total",
         "Number of DNS re-query operations performed.",
         &["result"]
     )
-    .unwrap()
-});
-
-pub static DNSTAP_PAYLOADS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
+    .unwrap();
+    pub static ref DNSTAP_PAYLOADS: DnstapPayloadsVec = register_static_int_counter_vec!(
+        DnstapPayloadsVec,
         "dnstap_replay_dnstap_payloads_total",
         "Number of dnstap payloads processed.",
         &["result"]
     )
-    .unwrap()
-});
+    .unwrap();
+    pub static ref DNSTAP_HANDLER_INTERNAL_ERRORS: DnstapHandlerInternalErrorsVec =
+        register_static_int_counter_vec!(
+            DnstapHandlerInternalErrorsVec,
+            "dnstap_replay_dnstap_handler_internal_errors_total",
+            "Number of internal errors encountered by dnstap handler.",
+            &["result"]
+        )
+        .unwrap();
+}
 
-pub static DNSTAP_HANDLER_INTERNAL_ERRORS: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "dnstap_replay_dnstap_handler_internal_errors_total",
-        "Number of internal errors encountered by dnstap handler.",
-        &["result"]
-    )
-    .unwrap()
-});
+pub fn initialize_metrics() {
+    initialize(&CHANNEL_ERROR_RX);
+    initialize(&CHANNEL_ERROR_TX);
+    initialize(&DATA_BYTES);
+    initialize(&DATA_FRAMES);
+    initialize(&DNS_COMPARISONS);
+    initialize(&DNS_QUERIES);
+    initialize(&DNSTAP_PAYLOADS);
+    initialize(&DNSTAP_HANDLER_INTERNAL_ERRORS);
+}


### PR DESCRIPTION
This commit converts dnstap-replay's metrics to use `lazy_static` (instead of `once_cell`) and `prometheus-static-metric`, and pre-initializes all the metrics at startup.

The use of `prometheus-static-metric` is slightly more efficient (it "reduces the amount of branching and processing needed at runtime to collect metrics" according to the documentation), but the main value is being able to pre-define the metric label values that will be used in dnstap-replay (since they're known at compile time), combined with calling `lazy_static::initialize()` on each metric at process startup.

This results in all the possible metrics and their label values being written out to the `/metrics` endpoint. For instance, here is the output of the `/metrics` endpoint from a freshly started dnstap-replay instance that has not processed any data yet:

    # HELP dnstap_replay_channel_error_rx_total Number of error channel receives performed.
    # TYPE dnstap_replay_channel_error_rx_total counter
    dnstap_replay_channel_error_rx_total{result="success"} 0
    # HELP dnstap_replay_channel_error_tx_total Number of error channel sends performed.
    # TYPE dnstap_replay_channel_error_tx_total counter
    dnstap_replay_channel_error_tx_total{result="error"} 0
    dnstap_replay_channel_error_tx_total{result="success"} 0
    # HELP dnstap_replay_data_bytes_total Number of Frame Streams data frame bytes processed.
    # TYPE dnstap_replay_data_bytes_total counter
    dnstap_replay_data_bytes_total 0
    # HELP dnstap_replay_data_frames_total Number of Frame Streams data frames processed.
    # TYPE dnstap_replay_data_frames_total counter
    dnstap_replay_data_frames_total 0
    # HELP dnstap_replay_dns_comparisons_total Number of DNS comparison operations performed.
    # TYPE dnstap_replay_dns_comparisons_total counter
    dnstap_replay_dns_comparisons_total{result="matched"} 0
    dnstap_replay_dns_comparisons_total{result="mismatched"} 0
    # HELP dnstap_replay_dns_queries_total Number of DNS re-query operations performed.
    # TYPE dnstap_replay_dns_queries_total counter
    dnstap_replay_dns_queries_total{result="error"} 0
    dnstap_replay_dns_queries_total{result="success"} 0
    dnstap_replay_dns_queries_total{result="timeout"} 0
    # HELP dnstap_replay_dnstap_handler_internal_errors_total Number of internal errors encountered by dnstap handler.
    # TYPE dnstap_replay_dnstap_handler_internal_errors_total counter
    dnstap_replay_dnstap_handler_internal_errors_total{result="discard_non_udp"} 0
    # HELP dnstap_replay_dnstap_payloads_total Number of dnstap payloads processed.
    # TYPE dnstap_replay_dnstap_payloads_total counter
    dnstap_replay_dnstap_payloads_total{result="error"} 0
    dnstap_replay_dnstap_payloads_total{result="success"} 0

This is apparently easier to process by downstream metric consumers compared to the previous behavior where metrics were being lazily initialized and were not appearing at all in the /metrics endpoint output until they had been incremented at least once.

Note: For the `dnstap_replay_dns_comparisons_total` metric, the "match" and "mismatch" label values were renamed to "matched" and "mismatched".  "match" is a Rust keyword and I was not able to find a way to escape this value.