### PR TITLE
Cargo.toml: Roll back the yanked dependency on futures-util 0.3.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ clap = "=3.0.0-beta.5"
 domain = "0.6.1"
 extfmt = "0.1.1"
 futures = "0.3.16"
-futures-util = "0.3.18"
+futures-util = "0.3.17"
 heck = "0.3.3"
 hex = "0.4.3"
 hyper = { version = "0.14.12", features = ["server", "stream", "http1", "tcp"] }


### PR DESCRIPTION
This commit rolls back the dependency on futures-util to the latest non-yanked version (0.3.18 was yanked). Otherwise this causes a build failure.