### PR TITLE
Cargo.toml: Remove license-file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["Fastly"]
 edition = "2018"
 repository = "https://github.com/fastly/dnstap-utils"
 license = "BSD-3-Clause"
-license-file = "LICENSE"
 
 [dependencies]
 anyhow = "1.0.43"


### PR DESCRIPTION
Fixes this warning from Cargo:

    warning: only one of `license` or `license-file` is necessary
    `license` should be used if the package license can be expressed with a standard SPDX expression.
    `license-file` should be used if the package uses a non-standard license.