### PR TITLE
replay: Add a dedicated "timeouts" channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,11 @@ encountered by `dnstap-replay`. This preserves the original DNS response
 message as well as the DNS response message sent by the target
 nameserver, which allows for byte-for-byte analysis of the mismatch.
 
+A separate `/timeouts` endpoint is available which can be used to
+retrieve dnstap log messages that resulted in timeouts when re-querying
+the target nameserver. The format used is the same as the `/errors`
+endpoint.
+
 [Prometheus metrics]: https://github.com/fastly/dnstap-utils/blob/main/src/bin/dnstap-replay/metrics.rs
 [dnstap `extra` field]: https://github.com/dnstap/dnstap.pb/blob/9bafb5b59dacc48a6ff6a839e419e540f1201c42/dnstap.proto#L37-L40
 
@@ -142,8 +147,11 @@ be sent to the target nameserver which should be configured to listen on
 The Prometheus metrics endpoint can be accessed at
 `http://127.0.0.1:53080/metrics`.
 
-The Frame Streams errors endpoint can be accessed at
+The Frame Streams "errors" endpoint can be accessed at
 `http://127.0.0.1:53080/errors`.
+
+The Frame Streams "timeouts" endpoint can be accessad at
+`http://127.0.0.1:53080/timeouts`.
 
 ## `dnstap-dump`
 

--- a/src/bin/dnstap-replay/dnstap_handler.rs
+++ b/src/bin/dnstap-replay/dnstap_handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Fastly, Inc.
+// Copyright 2021-2022 Fastly, Inc.
 
 use anyhow::{bail, Result};
 use bytes::{BufMut, Bytes, BytesMut};
@@ -53,6 +53,10 @@ pub struct DnstapHandler {
     /// protobuf messages to the [`crate::HttpHandler`].
     channel_error_sender: async_channel::Sender<dnstap::Dnstap>,
 
+    /// The send side of the async channel, used by [`DnstapHandler`]'s to send timeout dnstap
+    /// protobuf messages to the [`crate::HttpHandler`].
+    channel_timeout_sender: async_channel::Sender<dnstap::Dnstap>,
+
     /// Socket address/port of the DNS server to send DNS queries to.
     dns_address: SocketAddr,
 
@@ -87,6 +91,7 @@ impl DnstapHandler {
         match_status: Arc<AtomicBool>,
         channel_receiver: async_channel::Receiver<dnstap::Dnstap>,
         channel_error_sender: async_channel::Sender<dnstap::Dnstap>,
+        channel_timeout_sender: async_channel::Sender<dnstap::Dnstap>,
         dns_address: SocketAddr,
         proxy: bool,
         dscp: Option<u8>,
@@ -95,6 +100,7 @@ impl DnstapHandler {
             match_status,
             channel_receiver,
             channel_error_sender,
+            channel_timeout_sender,
             dns_address,
             proxy,
             dscp,
@@ -195,16 +201,18 @@ impl DnstapHandler {
                     // object's `extra` field.
                     d.extra = Some(e.serialize().to_vec());
 
-                    // Send the dnstap message to the errors channel so that it can be retrieved
-                    // from the /errors HTTP endpoint.
-                    self.send_error(d);
-
                     match e {
                         DnstapHandlerError::Mismatch(_, _, _) => {
+                            // Send to the errors channel.
+                            self.send_error(d);
+
                             crate::metrics::DNS_COMPARISONS.mismatched.inc();
                         }
 
                         DnstapHandlerError::Timeout => {
+                            // Send to the timeouts channel.
+                            self.send_timeout(d);
+
                             crate::metrics::DNS_QUERIES.timeout.inc();
 
                             // In the case of a DNS query timeout, we can't tell the difference
@@ -227,7 +235,10 @@ impl DnstapHandler {
                         }
 
                         DnstapHandlerError::MissingField => {
-                            // Already handled by metric increment above.
+                            // Send to the errors channel.
+                            self.send_error(d);
+
+                            // Metric increment already handled above.
                         }
                     }
                 } else if let Some(e) = e.downcast_ref::<DnstapHandlerInternalError>() {
@@ -353,6 +364,17 @@ impl DnstapHandler {
             }
             Err(_) => {
                 crate::metrics::CHANNEL_ERROR_TX.error.inc();
+            }
+        }
+    }
+
+    fn send_timeout(&self, d: dnstap::Dnstap) {
+        match self.channel_timeout_sender.try_send(d) {
+            Ok(_) => {
+                crate::metrics::CHANNEL_TIMEOUT_TX.success.inc();
+            }
+            Err(_) => {
+                crate::metrics::CHANNEL_TIMEOUT_TX.error.inc();
             }
         }
     }

--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Fastly, Inc.
+// Copyright 2021-2022 Fastly, Inc.
 
 use anyhow::Result;
 use async_channel::{bounded, Receiver, Sender};
@@ -52,6 +52,14 @@ struct Server {
     /// The receive side of the async channel used by [`DnstapHandler`]'s to send error dnstap
     /// protobuf messages to the [`HttpHandler`].
     channel_error_receiver: Receiver<dnstap::Dnstap>,
+
+    /// The send side of the async channel used by [`DnstapHandler`]'s to send timeout dnstap
+    /// protobuf messages to the [`HttpHandler`].
+    channel_timeout_sender: Sender<dnstap::Dnstap>,
+
+    /// The receive side of the async channel used by [`DnstapHandler`]'s to send timeout dnstap
+    /// protobuf messages to the [`HttpHandler`].
+    channel_timeout_receiver: Receiver<dnstap::Dnstap>,
 }
 
 /// Command-line arguments.
@@ -64,6 +72,10 @@ struct Opts {
     /// Capacity of async channel for /errors endpoint buffer
     #[clap(long, default_value = "100000")]
     channel_error_capacity: usize,
+
+    /// Capacity of async channel for /timeouts endpoint buffer
+    #[clap(long, default_value = "100000")]
+    channel_timeout_capacity: usize,
 
     /// UDP DNS server and port to send queries to
     #[clap(long, name = "DNS IP:PORT")]
@@ -125,8 +137,12 @@ impl Server {
         // Create the channel for connecting [`FrameHandler`]'s and [`DnstapHandler`]'s.
         let (channel_sender, channel_receiver) = bounded(opts.channel_capacity);
 
-        // Create the channel for connecting [`DnstapHandler`]'s and the [`HttpHandler`].
+        // Create the error channel for connecting [`DnstapHandler`]'s and the [`HttpHandler`].
         let (channel_error_sender, channel_error_receiver) = bounded(opts.channel_error_capacity);
+
+        // Create the timeout channel for connecting [`DnstapHandler`]'s and the [`HttpHandler`].
+        let (channel_timeout_sender, channel_timeout_receiver) =
+            bounded(opts.channel_timeout_capacity);
 
         Server {
             opts: opts.clone(),
@@ -134,6 +150,8 @@ impl Server {
             channel_receiver,
             channel_error_sender,
             channel_error_receiver,
+            channel_timeout_sender,
+            channel_timeout_receiver,
         }
     }
 
@@ -161,7 +179,9 @@ impl Server {
         }
 
         // Start up the [`HttpHandler`].
-        let http_handler = HttpHandler::new(self.opts.http, self.channel_error_receiver.clone());
+        let http_handler = HttpHandler::new(self.opts.http,
+                                            self.channel_error_receiver.clone(),
+                                            self.channel_timeout_receiver.clone());
         tokio::spawn(async move {
             if let Err(err) = http_handler.run().await {
                 error!("Hyper HTTP server error: {}", err);
@@ -177,6 +197,7 @@ impl Server {
                 match_status_dh,
                 self.channel_receiver.clone(),
                 self.channel_error_sender.clone(),
+                self.channel_timeout_sender.clone(),
                 self.opts.dns,
                 self.opts.proxy,
                 self.opts.dscp,

--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Fastly, Inc.
+// Copyright 2021-2022 Fastly, Inc.
 
 use lazy_static::{initialize, lazy_static};
 use prometheus::{
@@ -14,6 +14,19 @@ make_static_metric! {
     }
 
     pub struct ChannelErrorTxVec: IntCounter {
+        "result" => {
+            success,
+            error,
+        },
+    }
+
+    pub struct ChannelTimeoutRxVec: IntCounter {
+        "result" => {
+            success,
+        },
+    }
+
+    pub struct ChannelTimeoutTxVec: IntCounter {
         "result" => {
             success,
             error,
@@ -62,6 +75,20 @@ lazy_static! {
         ChannelErrorTxVec,
         "dnstap_replay_channel_error_tx_total",
         "Number of error channel sends performed.",
+        &["result"]
+    )
+    .unwrap();
+    pub static ref CHANNEL_TIMEOUT_RX: ChannelTimeoutRxVec = register_static_int_counter_vec!(
+        ChannelTimeoutRxVec,
+        "dnstap_replay_channel_timeout_rx_total",
+        "Number of timeout channel receives performed.",
+        &["result"]
+    )
+    .unwrap();
+    pub static ref CHANNEL_TIMEOUT_TX: ChannelTimeoutTxVec = register_static_int_counter_vec!(
+        ChannelTimeoutTxVec,
+        "dnstap_replay_channel_timeout_tx_total",
+        "Number of timeout channel sends performed.",
         &["result"]
     )
     .unwrap();
@@ -114,6 +141,8 @@ lazy_static! {
 pub fn initialize_metrics() {
     initialize(&CHANNEL_ERROR_RX);
     initialize(&CHANNEL_ERROR_TX);
+    initialize(&CHANNEL_TIMEOUT_RX);
+    initialize(&CHANNEL_TIMEOUT_TX);
     initialize(&DATA_BYTES);
     initialize(&DATA_FRAMES);
     initialize(&DNS_COMPARISONS);


### PR DESCRIPTION
This commit adds a dedicated "timeouts" channel used internally between `DnstapHandler` and `HttpHandler`, which is similar to the existing "errors" channel, and updates the `DnstapHandler` so that timeout messages are sent via the "timeouts" channel rather than the "errors" channel.

With this change, mismatches and timeouts will no longer be mixed together into the same "errors" channel.

This commit also introduces a new `/timeouts` HTTP endpoint for retrieving the current contents of the "timeouts" channel.

New metrics (`dnstap_replay_channel_timeout_rx_total` and `dnstap_replay_channel_timeout_tx_total`) are introduced for monitoring the utilization of the "timeouts" channel.