### PR TITLE
Cargo.toml: Update to latest, non-beta clap dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ async-channel = "1.6.1"
 async-stream = "0.3.2"
 bytes = "1.0.1"
 chrono = { version = "0.4.19", features = ["serde"] }
-clap = "=3.0.0-beta.5"
+clap = { version = "3.0.14", features = ["derive"] }
 domain = "0.6.1"
 extfmt = "0.1.1"
 futures = "0.3.16"


### PR DESCRIPTION
This commit drops the dependency on the exact version 3.0.0-beta.5 of clap. It turned out we needed to add the `derive` feature to the clap dependency to fix the build.