### PR TITLE
Cargo.toml: Bump Rust edition to 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "dnstap-utils"
 version = "0.1.0"
 authors = ["Fastly"]
-edition = "2018"
+edition = "2021"
 repository = "https://github.com/fastly/dnstap-utils"
 license = "BSD-3-Clause"
 


### PR DESCRIPTION
No other changes required.