### PR TITLE
replay: Add --match-status-delay command-line option

### DIFF
--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -97,6 +97,10 @@ struct Opts {
     #[clap(long)]
     proxy: bool,
 
+    /// Time to delay after status files match
+    #[clap(long, name = "MILLISECONDS", default_value = "5000", required = false)]
+    match_status_delay: u64,
+
     /// Match status files to compare
     #[clap(long = "match-status-files",
            name = "STATUS-FILE",
@@ -167,7 +171,8 @@ impl Server {
         // Start up the [`MonitorHandler'].
         if !self.opts.status_files.is_empty() {
             let match_status_mh = match_status.clone();
-            let mut monitor_handler = MonitorHandler::new(&self.opts.status_files)?;
+            let mut monitor_handler =
+                MonitorHandler::new(&self.opts.status_files, self.opts.match_status_delay)?;
             tokio::spawn(async move {
                 if let Err(err) = monitor_handler.run(match_status_mh).await {
                     error!("Monitor handler error: {}", err);


### PR DESCRIPTION
In practice, there can be a certain amount of buffered dnstap log messages between the dnstap sender and dnstap-replay which will take a non-zero length of time to reach dnstap-replay. By the time dnstap-replay re-queries the now out-of-date data, it can generate a spurious mismatch if the data used to generate the response has changed.

We can work around this issue by inserting a small delay between dnstap-replay's MonitorHandler noticing that the status files match and that change being propagated.

This commit adds a `--match-status-delay` command-line option to the dnstap-replay utility which causes the MonitorHandler to sleep for a configurable amount of time before propagating a status change in the false -> true direction.

This change is only relevant when the `--match-status-files` option to dnstap-replay is used.

The default setting for this option is 5 seconds (5000 milliseconds), which is a small multiple of the default "flush timeout" used in the Frame Streams implementation most commonly used by DNS servers:

https://github.com/farsightsec/fstrm/blob/1d6e11d750dfa8d15419814dfe0aa86d80000741/fstrm/iothr.h#L109-L133