### PR TITLE
replay: Correctly shift DSCP value when setting IP_TOS/IPV6_TCLASS option

### DIFF
--- a/src/bin/dnstap-replay/dnstap_handler.rs
+++ b/src/bin/dnstap-replay/dnstap_handler.rs
@@ -451,7 +451,7 @@ fn set_udp_dscp(s: &UdpSocket, dscp: u8) -> Result<()> {
     use std::os::unix::io::AsRawFd;
 
     let raw_fd = s.as_raw_fd();
-    let optval: libc::c_int = dscp.into();
+    let optval: libc::c_int = (dscp << 2).into();
 
     let ret = match s.local_addr()? {
         SocketAddr::V4(_) => unsafe {


### PR DESCRIPTION
The lower 2 bits of the IPv4 ToS / IPv6 traffic class byte are used to carry the ECN value. When calling `setsockopt()` to set the IP_TOS/IPV6_TCLASS value, the DSCP value needs to be shifted left by 2 bits.