### PR TITLE
replay: Add --ignore-tc option to ignore UDP mismatches when TC bit is set

### DIFF
--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -89,6 +89,10 @@ struct Opts {
     #[clap(long, name = "HTTP IP:PORT")]
     http: SocketAddr,
 
+    /// Whether to ignore UDP responses with the TC bit set
+    #[clap(long)]
+    ignore_tc: bool,
+
     /// Number of UDP client sockets to use to send queries to DNS server
     #[clap(long, default_value = "10")]
     num_sockets: usize,
@@ -206,6 +210,7 @@ impl Server {
                 self.opts.dns,
                 self.opts.proxy,
                 self.opts.dscp,
+                self.opts.ignore_tc,
             )
             .await?;
 

--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -38,6 +38,7 @@ make_static_metric! {
             matched,
             mismatched,
             suppressed,
+            udp_tc_ignored,
         },
     }
 


### PR DESCRIPTION
This commit adds a `--ignore-tc` command-line option that controls the behavior of the DnstapHandler's response message matching algorithm.

When enabled, this option avoids a type of nuisance mismatch where RRL is triggered and causes the TC bit to be set on a response. Since RRL is timing dependent and dnstap is heavily buffered, dnstap-replay may not replicate the exact same pattern of RRL-controlled responses, resulting in a mismatch.

If `--ignore-tc` is enabled and the pair of DNS response messages being analyzed don't match exactly, the response message headers will be further tested to see if one of the message headers has the TC bit set. If so, instead of being treated as a mismatch, a separate `udp_tc_ignored` metric will be incremented instead.