### PR TITLE
replay: Re-factor to reduce parameter passing

### DIFF
--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -64,7 +64,7 @@ struct Server {
 
 /// Command-line arguments.
 #[derive(Parser, Clone)]
-struct Opts {
+pub struct Opts {
     /// Capacity of async channel for handler payload distribution
     #[clap(long, default_value = "10000")]
     channel_capacity: usize,
@@ -203,14 +203,11 @@ impl Server {
 
             // Create a new [`DnstapHandler`] and give it a cloned channel receiver.
             let mut dnstap_handler = DnstapHandler::new(
+                &self.opts,
                 match_status_dh,
                 self.channel_receiver.clone(),
                 self.channel_error_sender.clone(),
                 self.channel_timeout_sender.clone(),
-                self.opts.dns,
-                self.opts.proxy,
-                self.opts.dscp,
-                self.opts.ignore_tc,
             )
             .await?;
 


### PR DESCRIPTION
This branch re-factors `dnstap-replay` to reduce the number of parameters that have to be passed around. The existing `Opts` structure that stores command-line options is now passed directly to `DnstapHandler::new()`, and the channels are encapsulated inside a new `Channels` structure.

This exposes some of the handler constructors to a few parameters they technically don't need but simplifies the set of parameters that have to be passed, e.g. `DnstapHandler::new()` goes from 9 parameters to 3 parameters with this branch.

This gets rids of the following clippy lint:

```
warning: this function has too many arguments (8/7)
   --> src/bin/dnstap-replay/dnstap_handler.rs:94:5
    |
94  | /     pub async fn new(
95  | |         match_status: Arc<AtomicBool>,
96  | |         channel_receiver: async_channel::Receiver<dnstap::Dnstap>,
97  | |         channel_error_sender: async_channel::Sender<dnstap::Dnstap>,
...   |
102 | |         ignore_tc: bool,
103 | |     ) -> Result<Self> {
    | |_____________________^
    |
    = note: `#[warn(clippy::too_many_arguments)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#too_many_arguments
```