### PR TITLE
fmt_dns_message(): Try to print most of the EDNS options

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -2,6 +2,7 @@
 
 use anyhow::{bail, Result};
 use bytes::{Buf, BufMut, Bytes, BytesMut};
+use domain::base::opt::AllOptData;
 use std::convert::TryFrom;
 use std::net::IpAddr;
 use thiserror::Error;
@@ -243,18 +244,134 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
             s.push('\n')
         }
 
-        if let Some(opt) = msg.opt() {
-            s.push('\n');
+        if let Some(optrec) = msg.opt() {
+            s.push_str("\n;; OPT PSEUDOSECTION:\n");
             s.push_str(prefix);
-            s.push_str(";; EDNS: version ");
-            s.push_str(&opt.version().to_string());
+            s.push_str("; EDNS: version ");
+            s.push_str(&optrec.version().to_string());
             s.push_str("; flags: ");
-            if opt.dnssec_ok() {
+            if optrec.dnssec_ok() {
                 s.push_str("do ");
             }
             s.push_str("; udp: ");
-            s.push_str(&opt.udp_payload_size().to_string());
+            s.push_str(&optrec.udp_payload_size().to_string());
             s.push('\n');
+
+            for opt in optrec.iter::<AllOptData<_>>().flatten() {
+                match opt {
+                    AllOptData::Nsid(nsid) => {
+                        s.push_str("; NSID: ");
+                        s.push_str(&nsid.to_string());
+                        if let Ok(nsid_data) = hex::decode(&nsid.to_string()) {
+                            if let Ok(nsid_str) = std::str::from_utf8(&nsid_data) {
+                                s.push_str(" (\"");
+                                s.push_str(nsid_str);
+                                s.push_str("\")");
+                            }
+                        }
+                        s.push('\n');
+                    }
+                    AllOptData::Dau(data) => {
+                        s.push_str("; DAU:");
+                        for alg in &data {
+                            s.push(' ');
+                            s.push_str(&alg.to_string());
+                        }
+                        s.push('\n');
+                    }
+                    AllOptData::Dhu(data) => {
+                        s.push_str("; DHU:");
+                        for alg in &data {
+                            s.push(' ');
+                            s.push_str(&alg.to_string());
+                        }
+                        s.push('\n');
+                    }
+                    AllOptData::N3u(data) => {
+                        s.push_str("; N3U:");
+                        for alg in &data {
+                            s.push(' ');
+                            s.push_str(&alg.to_string());
+                        }
+                        s.push('\n');
+                    }
+                    AllOptData::Expire(expire) => {
+                        s.push_str("; EXPIRE: ");
+                        if let Some(expire_data) = expire.expire() {
+                            s.push_str(&expire_data.to_string());
+                            s.push_str(" seconds");
+                        }
+                        s.push('\n');
+                    }
+                    AllOptData::TcpKeepalive(data) => {
+                        s.push_str("; TCP-KEEPALIVE: ");
+                        let iseconds = data.timeout() / 10;
+                        let fseconds = data.timeout() % 10;
+                        s.push_str(&iseconds.to_string());
+                        s.push('.');
+                        s.push_str(&fseconds.to_string());
+                        s.push_str(" seconds\n");
+                    }
+                    AllOptData::Padding(padding) => {
+                        s.push_str("; PADDING: [");
+                        s.push_str(&padding.len().to_string());
+                        s.push_str(" bytes]\n");
+                    }
+                    AllOptData::ClientSubnet(subnet) => {
+                        s.push_str("; CLIENT-SUBNET: ");
+                        s.push_str("\n;  NETWORK ADDRESS: ");
+                        s.push_str(&subnet.addr().to_string());
+                        s.push_str("\n;  SOURCE PREFIX-LENGTH: ");
+                        s.push_str(&subnet.source_prefix_len().to_string());
+                        s.push_str("\n;  SCOPE PREFIX-LENGTH: ");
+                        s.push_str(&subnet.scope_prefix_len().to_string());
+                        s.push('\n');
+                    }
+                    AllOptData::Cookie(data) => {
+                        s.push_str("; COOKIE: ");
+                        s.push_str(&hex::encode(data.cookie()));
+                        s.push('\n');
+                    }
+                    AllOptData::Chain(data) => {
+                        s.push_str("; CHAIN: ");
+                        s.push_str(&data.start().to_string());
+                        s.push('\n');
+                    }
+                    AllOptData::KeyTag(data) => {
+                        s.push_str("; KEY-TAG:");
+                        for keytag in &data {
+                            s.push(' ');
+                            s.push_str(&keytag.to_string());
+                        }
+                        s.push('\n');
+                    }
+                    AllOptData::ExtendedError(data) => {
+                        s.push_str("; EXTENDED-DNS-ERROR:\n");
+                        s.push_str(";  INFO-CODE: (");
+                        s.push_str(&data.code().to_int().to_string());
+                        s.push_str(") ");
+                        s.push_str(&data.code().to_string());
+                        s.push('\n');
+                        if let Some(text) = data.text() {
+                            if let Ok(text_str) = std::str::from_utf8(text) {
+                                s.push_str(";  EXTRA-TEXT: \"");
+                                s.push_str(text_str);
+                                s.push_str("\"\n");
+                            }
+                        }
+                    }
+                    AllOptData::Other(data) => {
+                        s.push_str("; OPT=");
+                        s.push_str(&data.code().to_int().to_string());
+                        s.push(':');
+                        s.push_str(&hex::encode(data.data()).to_uppercase());
+                        s.push('\n');
+                    }
+                    _ => {
+                        s.push_str("; Other unknown EDNS option, giving up.\n");
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This commit enhances `fmt_dns_message()` to print most of the known EDNS options in an ad hoc format.

This is a little bit fragile. If the EDNS option is malformed in some way, the opt record simply won't be present in the parsed message object, and nothing will be printed for the OPT pseudosection at all. But this is similar to the case today where the options are entirely ignored.

We might be able to simplify this code in an upcoming version of the `domain` crate (https://github.com/NLnetLabs/domain/issues/144).