### PR TITLE
fmt_dns_message(): Print prefix, simplify newline printing for EDNS options

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -272,7 +272,6 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                                 s.push_str("\")");
                             }
                         }
-                        s.push('\n');
                     }
                     AllOptData::Dau(data) => {
                         s.push_str("; DAU:");
@@ -280,7 +279,6 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                             s.push(' ');
                             s.push_str(&alg.to_string());
                         }
-                        s.push('\n');
                     }
                     AllOptData::Dhu(data) => {
                         s.push_str("; DHU:");
@@ -288,7 +286,6 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                             s.push(' ');
                             s.push_str(&alg.to_string());
                         }
-                        s.push('\n');
                     }
                     AllOptData::N3u(data) => {
                         s.push_str("; N3U:");
@@ -296,7 +293,6 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                             s.push(' ');
                             s.push_str(&alg.to_string());
                         }
-                        s.push('\n');
                     }
                     AllOptData::Expire(expire) => {
                         s.push_str("; EXPIRE: ");
@@ -304,7 +300,6 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                             s.push_str(&expire_data.to_string());
                             s.push_str(" seconds");
                         }
-                        s.push('\n');
                     }
                     AllOptData::TcpKeepalive(data) => {
                         s.push_str("; TCP-KEEPALIVE: ");
@@ -313,12 +308,12 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                         s.push_str(&iseconds.to_string());
                         s.push('.');
                         s.push_str(&fseconds.to_string());
-                        s.push_str(" seconds\n");
+                        s.push_str(" seconds");
                     }
                     AllOptData::Padding(padding) => {
                         s.push_str("; PADDING: [");
                         s.push_str(&padding.len().to_string());
-                        s.push_str(" bytes]\n");
+                        s.push_str(" bytes]");
                     }
                     AllOptData::ClientSubnet(subnet) => {
                         s.push_str("; CLIENT-SUBNET:\n");
@@ -333,17 +328,14 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                         s.push_str(prefix);
                         s.push_str(";  SCOPE PREFIX-LENGTH: ");
                         s.push_str(&subnet.scope_prefix_len().to_string());
-                        s.push('\n');
                     }
                     AllOptData::Cookie(data) => {
                         s.push_str("; COOKIE: ");
                         s.push_str(&hex::encode(data.cookie()));
-                        s.push('\n');
                     }
                     AllOptData::Chain(data) => {
                         s.push_str("; CHAIN: ");
                         s.push_str(&data.start().to_string());
-                        s.push('\n');
                     }
                     AllOptData::KeyTag(data) => {
                         s.push_str("; KEY-TAG:");
@@ -351,7 +343,6 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                             s.push(' ');
                             s.push_str(&keytag.to_string());
                         }
-                        s.push('\n');
                     }
                     AllOptData::ExtendedError(data) => {
                         s.push_str("; EXTENDED-DNS-ERROR:\n");
@@ -366,7 +357,7 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                                 s.push_str(prefix);
                                 s.push_str(";  EXTRA-TEXT: \"");
                                 s.push_str(text_str);
-                                s.push_str("\"\n");
+                                s.push('"');
                             }
                         }
                     }
@@ -375,12 +366,12 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                         s.push_str(&data.code().to_int().to_string());
                         s.push(':');
                         s.push_str(&hex::encode(data.data()).to_uppercase());
-                        s.push('\n');
                     }
                     _ => {
-                        s.push_str("; Other unknown EDNS option, giving up.\n");
+                        s.push_str("; Other unknown EDNS option, giving up.");
                     }
                 }
+                s.push('\n');
             }
         }
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -245,7 +245,9 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
         }
 
         if let Some(optrec) = msg.opt() {
-            s.push_str("\n;; OPT PSEUDOSECTION:\n");
+            s.push('\n');
+            s.push_str(prefix);
+            s.push_str(";; OPT PSEUDOSECTION:\n");
             s.push_str(prefix);
             s.push_str("; EDNS: version ");
             s.push_str(&optrec.version().to_string());
@@ -258,6 +260,7 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
             s.push('\n');
 
             for opt in optrec.iter::<AllOptData<_>>().flatten() {
+                s.push_str(prefix);
                 match opt {
                     AllOptData::Nsid(nsid) => {
                         s.push_str("; NSID: ");
@@ -318,12 +321,17 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                         s.push_str(" bytes]\n");
                     }
                     AllOptData::ClientSubnet(subnet) => {
-                        s.push_str("; CLIENT-SUBNET: ");
-                        s.push_str("\n;  NETWORK ADDRESS: ");
+                        s.push_str("; CLIENT-SUBNET:\n");
+                        s.push_str(prefix);
+                        s.push_str(";  NETWORK ADDRESS: ");
                         s.push_str(&subnet.addr().to_string());
-                        s.push_str("\n;  SOURCE PREFIX-LENGTH: ");
+                        s.push('\n');
+                        s.push_str(prefix);
+                        s.push_str(";  SOURCE PREFIX-LENGTH: ");
                         s.push_str(&subnet.source_prefix_len().to_string());
-                        s.push_str("\n;  SCOPE PREFIX-LENGTH: ");
+                        s.push('\n');
+                        s.push_str(prefix);
+                        s.push_str(";  SCOPE PREFIX-LENGTH: ");
                         s.push_str(&subnet.scope_prefix_len().to_string());
                         s.push('\n');
                     }
@@ -347,6 +355,7 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                     }
                     AllOptData::ExtendedError(data) => {
                         s.push_str("; EXTENDED-DNS-ERROR:\n");
+                        s.push_str(prefix);
                         s.push_str(";  INFO-CODE: (");
                         s.push_str(&data.code().to_int().to_string());
                         s.push_str(") ");
@@ -354,6 +363,7 @@ pub fn fmt_dns_message(s: &mut String, prefix: &str, raw_msg_bytes: &[u8]) {
                         s.push('\n');
                         if let Some(text) = data.text() {
                             if let Ok(text_str) = std::str::from_utf8(text) {
+                                s.push_str(prefix);
                                 s.push_str(";  EXTRA-TEXT: \"");
                                 s.push_str(text_str);
                                 s.push_str("\"\n");


### PR DESCRIPTION
The new EDNS option printing code needs to print out the `prefix` after a newline to support callers that need indentation (e.g. `dnstap-dump`). Also simplify the final newline print by hoisting it out of the match blocks.