### PR TITLE
replay: Add feature to ignore messages by `query_address`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,8 @@ dependencies = [
  "hex",
  "hyper",
  "inotify",
+ "ip_network",
+ "ip_network_table",
  "lazy_static",
  "libc",
  "log",
@@ -553,6 +555,28 @@ checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
 
 [[package]]
 name = "itertools"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ heck = "0.4.0"
 hex = "0.4.3"
 hyper = { version = "0.14.20", features = ["server", "stream", "http1", "tcp"] }
 inotify = "0.10.0"
+ip_network = "0.4.1"
+ip_network_table = "0.2.0"
 lazy_static = "1.4.0"
 libc = "0.2.137"
 log = "0.4.17"

--- a/src/bin/dnstap-replay/dnstap_handler.rs
+++ b/src/bin/dnstap-replay/dnstap_handler.rs
@@ -312,6 +312,15 @@ impl DnstapHandler {
             None => bail!(DnstapHandlerError::MissingField),
         };
 
+        // Check whether the query address matches any network in the table of networks to ignore
+        // queries from.
+        if let Some(table) = &self.ignore_query_nets {
+            if table.longest_match(query_address).is_some() {
+                crate::metrics::DNS_COMPARISONS.query_net_ignored.inc();
+                return Ok(());
+            };
+        };
+
         // Create a buffer for containing the original DNS client message, optionally with a PROXY
         // v2 header prepended. The PROXY v2 payload that we generate will be small (<100 bytes)
         // and DNS query messages are restricted by the protocol to a maximum size of 512 bytes.

--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -3,6 +3,7 @@
 use anyhow::Result;
 use async_channel::{bounded, Receiver, Sender};
 use clap::{ArgAction, Parser, ValueHint};
+use ip_network::IpNetwork;
 use log::*;
 use std::net::SocketAddr;
 use std::path::PathBuf;
@@ -100,6 +101,10 @@ pub struct Opts {
     /// Whether to ignore UDP responses with the TC bit set
     #[clap(long)]
     ignore_tc: bool,
+
+    /// Ignore queries from this IPv4 or IPv6 network
+    #[clap(long, value_parser = clap::value_parser!(IpNetwork))]
+    ignore_query_net: Vec<IpNetwork>,
 
     /// Number of UDP client sockets to use to send queries to DNS server
     #[clap(long, default_value = "10")]

--- a/src/bin/dnstap-replay/metrics.rs
+++ b/src/bin/dnstap-replay/metrics.rs
@@ -39,6 +39,7 @@ make_static_metric! {
             mismatched,
             suppressed,
             udp_tc_ignored,
+            query_net_ignored,
         },
     }
 


### PR DESCRIPTION
This branch adds a feature to `dnstap-replay` to ignore dnstap messages for replay/comparison purposes that match a longest prefix match blocklist. The blocklist is specified on the command-line by using the new `--ignore-query-net` option for each IPv4/IPv6 network prefix to be ignored. Any dnstap messages that are ignored due to this new filtering feature will utilize the new result code `query_net_ignored` for the `dnstap_replay_dns_comparisons_total` metric.

The underlying longest network prefix match implementation is [`ip_network_table`](https://crates.io/crates/ip_network_table).