### PR TITLE
replay: Add `--proxy-timespec` command-line flag to add custom PROXY v2 timespec TLV

### DIFF
--- a/src/bin/dnstap-replay/dnstap_handler.rs
+++ b/src/bin/dnstap-replay/dnstap_handler.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 Fastly, Inc.
+// Copyright 2021-2023 Fastly, Inc.
 
 use anyhow::{bail, Result};
 use bytes::{BufMut, Bytes, BytesMut};
@@ -71,6 +71,12 @@ pub struct DnstapHandler {
 enum DnstapHandlerInternalError {
     #[error("Non-UDP dnstap payload was discarded")]
     DiscardNonUdp,
+}
+
+#[derive(Debug)]
+struct Timespec {
+    pub seconds: u64,
+    pub nanoseconds: u32,
 }
 
 impl DnstapHandler {
@@ -328,7 +334,18 @@ impl DnstapHandler {
 
         // Add the PROXY v2 payload, if the dnstap handler has been configured to do so.
         if self.opts.proxy {
-            add_proxy_payload(&mut buf, msg, &query_address)?;
+            // Check if the dnstap handler has also been configured to add the timespec TLV to the
+            // PROXY v2 payload.
+            let timespec = if self.opts.proxy_timespec {
+                Some(Timespec {
+                    seconds: msg.response_time_sec(),
+                    nanoseconds: msg.response_time_nsec(),
+                })
+            } else {
+                None
+            };
+
+            add_proxy_payload(&mut buf, msg, &query_address, timespec)?;
         }
 
         // Add the original DNS query message.
@@ -420,7 +437,28 @@ fn add_proxy_payload(
     buf: &mut BytesMut,
     msg: &dnstap::Message,
     query_address: &IpAddr,
+    timespec: Option<Timespec>,
 ) -> Result<()> {
+    // Codepoint in the range between `PP2_TYPE_MIN_CUSTOM` (0xE0) and `PP2_TYPE_MAX_CUSTOM`
+    // (0xEF). This range is "reserved for application-specific data and will never be used by the
+    // PROXY Protocol."
+    const PP2_TYPE_CUSTOM_TIMESPEC: u8 = 0xEA;
+
+    // u8 `type` (1 byte)
+    // u8 `length_hi` (1 byte)
+    // u8 `length_lo` (1 byte)
+    // u64 `query_time_sec` (8 bytes)
+    // u32 `query_time_nsec` (4 bytes)
+    const PP2_CUSTOM_TIMESPEC_SIZE: u16 = 3 + 8 + 4;
+
+    // Calculate the number of bytes following the address block needed for the following TLV(s).
+    // This is zero if the timespec TLV is not going to be written into the PROXY v2 payload.
+    let needed_tlv_size = if timespec.is_some() {
+        PP2_CUSTOM_TIMESPEC_SIZE
+    } else {
+        0
+    };
+
     // Extract the `query_port` field.
     let query_port = match &msg.query_port {
         Some(port) => *port as u16,
@@ -441,7 +479,9 @@ fn add_proxy_payload(
 
             // Size of the UDP-over-IPv4 address block: 12 bytes. There are two IPv4 addresses
             // (4 bytes each) and two UDP port numbers (2 bytes each).
-            buf.put_u16(12);
+            //
+            // Also add the size of the TLV(s) after the address block.
+            buf.put_u16(12 + needed_tlv_size);
 
             // Original IPv4 source address.
             buf.put_slice(&addr.octets());
@@ -456,7 +496,9 @@ fn add_proxy_payload(
 
             // Size of the UDP-over-IPv6 address block: 36 bytes. There are two IPv6 addresses
             // (16 bytes each) and two UDP port numbers (2 bytes each).
-            buf.put_u16(36);
+            //
+            // Also add the size of the TLV(s) after the address block.
+            buf.put_u16(36 + needed_tlv_size);
 
             // Original IPv6 source address.
             buf.put_slice(&addr.octets());
@@ -473,6 +515,22 @@ fn add_proxy_payload(
     // Original UDP destination port. Use 53 since it doesn't matter and the dnstap message
     // payload may not have it.
     buf.put_u16(53);
+
+    if let Some(timespec) = timespec {
+        trace!("Sending PROXY v2 custom TLV: {timespec:?}");
+
+        // Timespec TLV: type field.
+        buf.put_u8(PP2_TYPE_CUSTOM_TIMESPEC);
+
+        // Timespec TLV: length field. This is split into a "high byte" and "low byte". The length is
+        // of the following value (8 bytes u64 + 4 bytes u32).
+        buf.put_u8(0);
+        buf.put_u8(12);
+
+        // Timespec TLV: value field. Intentionally encode using little endian byte order.
+        buf.put_u64_le(timespec.seconds);
+        buf.put_u32_le(timespec.nanoseconds);
+    }
 
     Ok(())
 }

--- a/src/bin/dnstap-replay/main.rs
+++ b/src/bin/dnstap-replay/main.rs
@@ -1,4 +1,4 @@
-// Copyright 2021-2022 Fastly, Inc.
+// Copyright 2021-2023 Fastly, Inc.
 
 use anyhow::Result;
 use async_channel::{bounded, Receiver, Sender};
@@ -113,6 +113,10 @@ pub struct Opts {
     /// Whether to add PROXY v2 header to re-sent DNS queries
     #[clap(long)]
     proxy: bool,
+
+    /// Whether to add timespec TLV to PROXY v2 header
+    #[clap(long)]
+    proxy_timespec: bool,
 
     /// Time to delay after status files match
     #[clap(long, name = "MILLISECONDS", default_value = "5000", required = false)]


### PR DESCRIPTION
This commit adds a `--proxy-timespec` command-line flag to the dnstap-replay utility that controls the behavior of the PROXY v2 encoder (if `--proxy` is also set).

The PROXY v2 protocol supports [encoding additional TLVs] after the address block:

    If the length specified in the PROXY protocol header indicates that
    additional bytes are part of the header beyond the address
    information, a receiver may choose to skip over and ignore those
    bytes, or attempt to interpret those bytes.

    The information in those bytes will be arranged in Type-Length-Value
    (TLV vectors) in the following format. The first byte is the Type of
    the vector. The second two bytes represent the length in bytes of
    the value (not included the Type and Length bytes), and following
    the length field is the number of bytes specified by the length.

            struct pp2_tlv {
                uint8_t type;
                uint8_t length_hi;
                uint8_t length_lo;
                uint8_t value[0];
            };

    A receiver may choose to skip over and ignore the TLVs it is not
    interested in or it does not understand. Senders can generate the
    TLVs only for the information they choose to publish.

Additional, there is a range of TLV codepoints [reserved for application-specific data]:

    The following range of 16 type values is reserved for
    application-specific data and will be never used by the PROXY
    Protocol. If you need more values consider extending the range with
    a type field in your TLVs.

            #define PP2_TYPE_MIN_CUSTOM    0xE0
            #define PP2_TYPE_MAX_CUSTOM    0xEF

This commit uses the codepoint 0xEA for dnstap-replay's PROXY v2 timespec TLV. This TLV represents the timestamp at which the original DNS response was processed. This allows the DNS server under test (receiving replayed DNS queries with prepended PROXY v2 headers) to recover the original timestamp of the DNS query, which allows for testing time-dependent behavior. Because of buffering and processing latency, etc. there can be a small but non-negligible amount of delay (up to a few seconds) between when the original DNS server responds to the original query and when the DNS server under test processes the replayed DNS query.

The timespec TLV encodes a "timespec"-compatible structure which represents the number of seconds elapsed since the Unix epoch, represented as a combination of a whole number (seconds) and fractional part (nanoseconds). The whole number is represented as a little endian 64-bit integer and the fractional part is represented as a little endian 32-bit integer.

[encoding additional TLVs]: https://github.com/haproxy/haproxy/blob/v2.7.0/doc/proxy-protocol.txt#L514-L534
[reserved for application-specific data]: https://github.com/haproxy/haproxy/blob/v2.7.0/doc/proxy-protocol.txt#L677-L682