### PR TITLE
Removed unused dependencies `extfmt`, `simple-error`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,7 +238,6 @@ dependencies = [
  "chrono",
  "clap",
  "domain",
- "extfmt",
  "futures",
  "futures-util",
  "heck",
@@ -254,7 +253,6 @@ dependencies = [
  "prometheus-static-metric",
  "prost",
  "prost-build",
- "simple-error",
  "stderrlog",
  "thiserror",
  "tokio",
@@ -303,12 +301,6 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
-
-[[package]]
-name = "extfmt"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a48fe53466ab1f4ea6303bf9d7a0ca8060778590f09fd6c3304cc817aeb9935d"
 
 [[package]]
 name = "fastrand"
@@ -1068,12 +1060,6 @@ checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "simple-error"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc47a29ce97772ca5c927f75bac34866b16d64e07f330c3248e2d7226623901b"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,6 @@ bytes = "1.4.0"
 chrono = { version = "0.4.23", features = ["serde"] }
 clap = { version = "4.1.4", features = ["derive"] }
 domain = "0.7.1"
-extfmt = "0.1.1"
 futures = "0.3.26"
 futures-util = "0.3.26"
 heck = "0.4.1"
@@ -33,7 +32,6 @@ log = "0.4.17"
 prometheus = "0.13.3"
 prometheus-static-metric = "0.5.1"
 prost = "0.11.6"
-simple-error = "0.2.3"
 stderrlog = "0.5.4"
 thiserror = "1.0.38"
 tokio = { version = "1.25.0", features = ["full"] }


### PR DESCRIPTION
Found using [cargo-udeps](https://github.com/est31/cargo-udeps):

    redmonds@fastly{0}:~/dnstap-utils$ cargo +nightly udeps --all-targets
       Compiling dnstap-utils v0.4.0 (/home/redmonds/github/dnstap-utils)
        Finished dev [unoptimized + debuginfo] target(s) in 1.53s
    […]
    unused dependencies:
    `dnstap-utils v0.4.0 (/home/redmonds/github/dnstap-utils)`
    └─── dependencies
         ├─── "extfmt"
         └─── "simple-error"
    Note: They might be false-positive.
          For example, `cargo-udeps` cannot detect usage of crates that are only used in doc-tests.
          To ignore some dependencies, write `package.metadata.cargo-udeps.ignore` in Cargo.toml.