### PR TITLE
Add a new utility `dnstap-inject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ hex-encoded wire format as well as in dig-style output.
 
 [`dnstap-ldns`]: https://github.com/dnstap/dnstap-ldns
 
+## `dnstap-inject`
+
+`dnstap-inject` is a utility which reads a Frame Streams formatted
+dnstap file, extracts messages which contain both a `query_address` and
+`query_message` field, and re-sends the query message to a DNS server.
+It can optionally prepend a PROXYv2 header to the query sent to the DNS
+server (if supported by the server) in order to exercise source address
+dependent behavior.
+
 ## `fmt-dns-message`
 
 `fmt-dns-message` is a utility which converts a hex-encoded wire format

--- a/src/bin/dnstap-inject/main.rs
+++ b/src/bin/dnstap-inject/main.rs
@@ -1,0 +1,202 @@
+// Copyright 2021-2024 Fastly, Inc.
+
+use anyhow::{bail, Result};
+use bytes::{BufMut, BytesMut};
+use clap::{ArgAction, Parser, ValueHint};
+use log::*;
+use prost::Message;
+use std::fmt::Debug;
+use std::net::{IpAddr, SocketAddr};
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::fs::File;
+use tokio::net::UdpSocket;
+use tokio::time::timeout;
+use tokio_stream::StreamExt;
+use tokio_util::codec::Framed;
+
+use dnstap_utils::dnstap;
+use dnstap_utils::framestreams_codec::{Frame, FrameStreamsCodec};
+use dnstap_utils::proxyv2;
+use dnstap_utils::util::try_from_u8_slice_for_ipaddr;
+
+/// Duration to wait for a response from the DNS server under test.
+const DNS_QUERY_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Parser, Debug)]
+struct Opts {
+    /// Read dnstap data from file
+    #[clap(short = 'r',
+           long = "read",
+           name = "FILE",
+           value_parser,
+           value_hint = ValueHint::FilePath)
+    ]
+    file: PathBuf,
+
+    /// UDP DNS server and port to send queries to
+    #[clap(long, name = "DNS IP:PORT")]
+    dns: SocketAddr,
+
+    /// Whether to add PROXY v2 header to re-sent DNS queries
+    #[clap(long)]
+    proxy: bool,
+
+    /// Increase verbosity level
+    #[clap(short, long, action = ArgAction::Count)]
+    verbose: u8,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Workaround for https://github.com/rust-lang/rust/issues/62569
+    if cfg!(unix) {
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
+    }
+
+    let opts = Opts::parse();
+
+    stderrlog::new()
+        .verbosity(opts.verbose as usize)
+        .module(module_path!())
+        .init()
+        .unwrap();
+
+    let file = File::open(opts.file).await?;
+    let socket = setup_socket(&opts.dns).await?;
+
+    let mut framed = Framed::new(file, FrameStreamsCodec {});
+    while let Some(frame) = framed.next().await {
+        match frame {
+            Ok(frame) => match frame {
+                Frame::ControlReady(_) => {
+                    bail!("Protocol error: READY frame not allowed here");
+                }
+                Frame::ControlAccept(_) => {
+                    bail!("Protocol error: ACCEPT frame not allowed here");
+                }
+                Frame::ControlStart(_) => {
+                    // XXX: Validate the content type embedded in the Start control frame payload.
+                }
+                Frame::ControlStop => {
+                    return Ok(());
+                }
+                Frame::ControlFinish => {
+                    bail!("Protocol error: FINISH frame not allowed here");
+                }
+                Frame::ControlUnknown(_) => {
+                    bail!("Protocol error: Unknown control frame");
+                }
+                Frame::Data(mut payload) => match dnstap::Dnstap::decode(&mut payload) {
+                    Ok(d) => {
+                        process_dnstap_frame(&socket, opts.proxy, d).await?;
+                    }
+                    Err(e) => {
+                        bail!(
+                            "Protocol error: Decoding dnstap protobuf message: {}, payload: {}",
+                            e,
+                            hex::encode(&payload)
+                        );
+                    }
+                },
+            },
+            Err(e) => {
+                bail!("Protocol error: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn setup_socket(server_addr: &SocketAddr) -> Result<UdpSocket> {
+    let local_addr: SocketAddr = if server_addr.is_ipv4() {
+        "0.0.0.0:0"
+    } else {
+        "[::]:0"
+    }
+    .parse()?;
+
+    let socket = UdpSocket::bind(local_addr).await?;
+    socket.connect(server_addr).await?;
+    debug!("Connected socket to DNS server: {:?}", &socket);
+    Ok(socket)
+}
+
+async fn process_dnstap_frame(socket: &UdpSocket, proxy: bool, d: dnstap::Dnstap) -> Result<()> {
+    if let Ok(dtype) = dnstap::dnstap::Type::try_from(d.r#type) {
+        if dtype == dnstap::dnstap::Type::Message {
+            if let Some(msg) = &d.message {
+                process_dnstap_message(socket, proxy, msg).await?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn process_dnstap_message(
+    socket: &UdpSocket,
+    proxy: bool,
+    msg: &dnstap::Message,
+) -> Result<()> {
+    if let Some(query_address) = &msg.query_address {
+        if let Ok(query_address) = try_from_u8_slice_for_ipaddr(query_address) {
+            if msg.query_message.is_some() {
+                send_query(socket, proxy, &query_address, msg).await?;
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn send_query(
+    socket: &UdpSocket,
+    proxy: bool,
+    query_address: &IpAddr,
+    msg: &dnstap::Message,
+) -> Result<()> {
+    if let Some(query_message) = &msg.query_message {
+        // Buffer to received UDP response messages from the DNS server under test.
+        let mut recv_buf: [u8; 4096] = [0; 4096];
+
+        // Create a buffer for containing the original DNS query message, optionally with a PROXY v2
+        // header prepended.
+        let mut buf = BytesMut::with_capacity(1024);
+
+        if proxy {
+            proxyv2::add_proxy_payload(&mut buf, msg, query_address, None)?;
+        }
+
+        // Add the original DNS query message.
+        buf.put_slice(query_message);
+
+        // Freeze the buffer since it no longer needs to be mutated.
+        let buf = buf.freeze();
+
+        // Send the constructed query message to the DNS server under test.
+        trace!("Sending DNS query: {}", hex::encode(query_message));
+        socket.send(&buf).await?;
+
+        // Receive the DNS response message from the DNS server under test, or wait for the DNS
+        // query timeout to expire.
+        match timeout(DNS_QUERY_TIMEOUT, socket.recv(&mut recv_buf)).await {
+            Ok(res) => match res {
+                Ok(n_bytes) => {
+                    let received_message = &recv_buf[..n_bytes];
+                    trace!("Received DNS response: {}", hex::encode(received_message));
+                }
+                Err(e) => {
+                    error!("Error while receiving response: {}", e);
+                }
+            },
+            Err(e) => {
+                error!("Timeout: {}", e);
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/src/bin/dnstap-replay/dnstap_handler.rs
+++ b/src/bin/dnstap-replay/dnstap_handler.rs
@@ -4,7 +4,7 @@ use anyhow::{bail, Result};
 use bytes::{BufMut, Bytes, BytesMut};
 use ip_network_table::IpNetworkTable;
 use log::*;
-use std::net::{IpAddr, SocketAddr};
+use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::Duration;
@@ -13,6 +13,7 @@ use tokio::net::UdpSocket;
 use tokio::time::timeout;
 
 use dnstap_utils::dnstap;
+use dnstap_utils::proxyv2;
 use dnstap_utils::util::dns_message_is_truncated;
 use dnstap_utils::util::try_from_u8_slice_for_ipaddr;
 use dnstap_utils::util::DnstapHandlerError;
@@ -71,12 +72,6 @@ pub struct DnstapHandler {
 enum DnstapHandlerInternalError {
     #[error("Non-UDP dnstap payload was discarded")]
     DiscardNonUdp,
-}
-
-#[derive(Debug)]
-struct Timespec {
-    pub seconds: u64,
-    pub nanoseconds: u32,
 }
 
 impl DnstapHandler {
@@ -199,8 +194,7 @@ impl DnstapHandler {
         };
 
         // Check if this is an `AUTH_RESPONSE` type dnstap "Message" object.
-        if dnstap::message::Type::try_from(msg.r#type) != Ok(dnstap::message::Type::AuthResponse)
-        {
+        if dnstap::message::Type::try_from(msg.r#type) != Ok(dnstap::message::Type::AuthResponse) {
             return Ok(());
         }
 
@@ -337,7 +331,7 @@ impl DnstapHandler {
             // Check if the dnstap handler has also been configured to add the timespec TLV to the
             // PROXY v2 payload.
             let timespec = if self.opts.proxy_timespec {
-                Some(Timespec {
+                Some(proxyv2::Timespec {
                     seconds: msg.response_time_sec(),
                     nanoseconds: msg.response_time_nsec(),
                 })
@@ -345,7 +339,7 @@ impl DnstapHandler {
                 None
             };
 
-            add_proxy_payload(&mut buf, msg, &query_address, timespec)?;
+            proxyv2::add_proxy_payload(&mut buf, msg, &query_address, timespec)?;
         }
 
         // Add the original DNS query message.
@@ -431,108 +425,6 @@ impl DnstapHandler {
             }
         }
     }
-}
-
-fn add_proxy_payload(
-    buf: &mut BytesMut,
-    msg: &dnstap::Message,
-    query_address: &IpAddr,
-    timespec: Option<Timespec>,
-) -> Result<()> {
-    // Codepoint in the range between `PP2_TYPE_MIN_CUSTOM` (0xE0) and `PP2_TYPE_MAX_CUSTOM`
-    // (0xEF). This range is "reserved for application-specific data and will never be used by the
-    // PROXY Protocol."
-    const PP2_TYPE_CUSTOM_TIMESPEC: u8 = 0xEA;
-
-    // u8 `type` (1 byte)
-    // u8 `length_hi` (1 byte)
-    // u8 `length_lo` (1 byte)
-    // u64 `query_time_sec` (8 bytes)
-    // u32 `query_time_nsec` (4 bytes)
-    const PP2_CUSTOM_TIMESPEC_SIZE: u16 = 3 + 8 + 4;
-
-    // Calculate the number of bytes following the address block needed for the following TLV(s).
-    // This is zero if the timespec TLV is not going to be written into the PROXY v2 payload.
-    let needed_tlv_size = if timespec.is_some() {
-        PP2_CUSTOM_TIMESPEC_SIZE
-    } else {
-        0
-    };
-
-    // Extract the `query_port` field.
-    let query_port = match &msg.query_port {
-        Some(port) => *port as u16,
-        None => bail!(DnstapHandlerError::MissingField),
-    };
-
-    // Add the PROXY v2 signature.
-    buf.put(&b"\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"[..]);
-
-    // Add the PROXY version (2) and command (1), PROXY.
-    buf.put_u8(0x21);
-
-    // Add the PROXY v2 address block.
-    match query_address {
-        IpAddr::V4(addr) => {
-            // UDP-over-IPv4: protocol constant 0x12.
-            buf.put_u8(0x12);
-
-            // Size of the UDP-over-IPv4 address block: 12 bytes. There are two IPv4 addresses
-            // (4 bytes each) and two UDP port numbers (2 bytes each).
-            //
-            // Also add the size of the TLV(s) after the address block.
-            buf.put_u16(12 + needed_tlv_size);
-
-            // Original IPv4 source address.
-            buf.put_slice(&addr.octets());
-
-            // Original IPv4 destination address. Use 0.0.0.0 since it doesn't matter and the
-            // dnstap message payload may not have it.
-            buf.put_u32(0);
-        }
-        IpAddr::V6(addr) => {
-            // UDP-over-IPv6: protocol constant 0x22.
-            buf.put_u8(0x22);
-
-            // Size of the UDP-over-IPv6 address block: 36 bytes. There are two IPv6 addresses
-            // (16 bytes each) and two UDP port numbers (2 bytes each).
-            //
-            // Also add the size of the TLV(s) after the address block.
-            buf.put_u16(36 + needed_tlv_size);
-
-            // Original IPv6 source address.
-            buf.put_slice(&addr.octets());
-
-            // Original IPv6 destination address. Use :: since it doesn't matter and the dnstap
-            // message payload may not have it.
-            buf.put_u128(0);
-        }
-    };
-
-    // Original UDP source port.
-    buf.put_u16(query_port);
-
-    // Original UDP destination port. Use 53 since it doesn't matter and the dnstap message
-    // payload may not have it.
-    buf.put_u16(53);
-
-    if let Some(timespec) = timespec {
-        trace!("Sending PROXY v2 custom TLV: {timespec:?}");
-
-        // Timespec TLV: type field.
-        buf.put_u8(PP2_TYPE_CUSTOM_TIMESPEC);
-
-        // Timespec TLV: length field. This is split into a "high byte" and "low byte". The length is
-        // of the following value (8 bytes u64 + 4 bytes u32).
-        buf.put_u8(0);
-        buf.put_u8(12);
-
-        // Timespec TLV: value field. Intentionally encode using little endian byte order.
-        buf.put_u64_le(timespec.seconds);
-        buf.put_u32_le(timespec.nanoseconds);
-    }
-
-    Ok(())
 }
 
 /// Utility function that sets the DSCP value on a UDP socket.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2021 Fastly, Inc.
+// Copyright 2021-2024 Fastly, Inc.
 
 pub mod dnstap {
     #![allow(clippy::module_inception)]
@@ -8,4 +8,5 @@ pub mod dnstap {
 
 pub mod framestreams_codec;
 
+pub mod proxyv2;
 pub mod util;

--- a/src/proxyv2.rs
+++ b/src/proxyv2.rs
@@ -1,0 +1,116 @@
+// Copyright 2021-2024 Fastly, Inc.
+
+use anyhow::{bail, Result};
+use bytes::{BufMut, BytesMut};
+use log::*;
+use std::net::IpAddr;
+
+use crate::{dnstap, util::DnstapHandlerError};
+
+#[derive(Debug)]
+pub struct Timespec {
+    pub seconds: u64,
+    pub nanoseconds: u32,
+}
+
+pub fn add_proxy_payload(
+    buf: &mut BytesMut,
+    msg: &dnstap::Message,
+    query_address: &IpAddr,
+    timespec: Option<Timespec>,
+) -> Result<()> {
+    // Codepoint in the range between `PP2_TYPE_MIN_CUSTOM` (0xE0) and `PP2_TYPE_MAX_CUSTOM`
+    // (0xEF). This range is "reserved for application-specific data and will never be used by the
+    // PROXY Protocol."
+    const PP2_TYPE_CUSTOM_TIMESPEC: u8 = 0xEA;
+
+    // u8 `type` (1 byte)
+    // u8 `length_hi` (1 byte)
+    // u8 `length_lo` (1 byte)
+    // u64 `query_time_sec` (8 bytes)
+    // u32 `query_time_nsec` (4 bytes)
+    const PP2_CUSTOM_TIMESPEC_SIZE: u16 = 3 + 8 + 4;
+
+    // Calculate the number of bytes following the address block needed for the following TLV(s).
+    // This is zero if the timespec TLV is not going to be written into the PROXY v2 payload.
+    let needed_tlv_size = if timespec.is_some() {
+        PP2_CUSTOM_TIMESPEC_SIZE
+    } else {
+        0
+    };
+
+    // Extract the `query_port` field.
+    let query_port = match &msg.query_port {
+        Some(port) => *port as u16,
+        None => bail!(DnstapHandlerError::MissingField),
+    };
+
+    // Add the PROXY v2 signature.
+    buf.put(&b"\x0D\x0A\x0D\x0A\x00\x0D\x0A\x51\x55\x49\x54\x0A"[..]);
+
+    // Add the PROXY version (2) and command (1), PROXY.
+    buf.put_u8(0x21);
+
+    // Add the PROXY v2 address block.
+    match query_address {
+        IpAddr::V4(addr) => {
+            // UDP-over-IPv4: protocol constant 0x12.
+            buf.put_u8(0x12);
+
+            // Size of the UDP-over-IPv4 address block: 12 bytes. There are two IPv4 addresses
+            // (4 bytes each) and two UDP port numbers (2 bytes each).
+            //
+            // Also add the size of the TLV(s) after the address block.
+            buf.put_u16(12 + needed_tlv_size);
+
+            // Original IPv4 source address.
+            buf.put_slice(&addr.octets());
+
+            // Original IPv4 destination address. Use 0.0.0.0 since it doesn't matter and the
+            // dnstap message payload may not have it.
+            buf.put_u32(0);
+        }
+        IpAddr::V6(addr) => {
+            // UDP-over-IPv6: protocol constant 0x22.
+            buf.put_u8(0x22);
+
+            // Size of the UDP-over-IPv6 address block: 36 bytes. There are two IPv6 addresses
+            // (16 bytes each) and two UDP port numbers (2 bytes each).
+            //
+            // Also add the size of the TLV(s) after the address block.
+            buf.put_u16(36 + needed_tlv_size);
+
+            // Original IPv6 source address.
+            buf.put_slice(&addr.octets());
+
+            // Original IPv6 destination address. Use :: since it doesn't matter and the dnstap
+            // message payload may not have it.
+            buf.put_u128(0);
+        }
+    };
+
+    // Original UDP source port.
+    buf.put_u16(query_port);
+
+    // Original UDP destination port. Use 53 since it doesn't matter and the dnstap message
+    // payload may not have it.
+    buf.put_u16(53);
+
+    if let Some(timespec) = timespec {
+        trace!("Sending PROXY v2 custom TLV: {timespec:?}");
+
+        // Timespec TLV: type field.
+        buf.put_u8(PP2_TYPE_CUSTOM_TIMESPEC);
+
+        // Timespec TLV: length field. This is split into a "high byte" and "low byte". The length is
+        // of the following value (8 bytes u64 + 4 bytes u32).
+        buf.put_u8(0);
+        buf.put_u8(12);
+
+        // Timespec TLV: value field. Intentionally encode using little endian byte order.
+        buf.put_u64_le(timespec.seconds);
+        buf.put_u32_le(timespec.nanoseconds);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This branch adds a new command-line utility `dnstap-inject`.

`dnstap-inject` is a utility which reads a Frame Streams formatted dnstap file, extracts messages which contain both a `query_address` and `query_message` field, and re-sends the query message to a DNS server. It can optionally prepend a PROXYv2 header to the query sent to the DNS server (if supported by the server) in order to exercise source address dependent behavior.

The existing PROXYv2 payload handling functionality is factored out of `dnstap-replay` and moved into the library so it can be reused in `dnstap-inject`.